### PR TITLE
Fixes Wi-Fi network adapter name

### DIFF
--- a/RestartWiFiAdapter.xml
+++ b/RestartWiFiAdapter.xml
@@ -41,7 +41,7 @@
   <Actions Context="Author">
     <Exec>
       <Command>cmd.exe</Command>
-      <Arguments>/c "netsh interface set interface WiFi DISABLED &amp; netsh interface set interface WiFi ENABLED"</Arguments>
+      <Arguments>/c "netsh interface set interface Wi-Fi DISABLED &amp; netsh interface set interface Wi-Fi ENABLED"</Arguments>
     </Exec>
   </Actions>
 </Task>


### PR DESCRIPTION
Wi-Fi interface, is named "Wi-Fi", as per "netsh interface show interface" command.
Provided script install correctly the scheduled task, however the command itself cannot run with success.

Tested on a Surface 3 device, running Windows 10.0.10586 with Italian localization.
